### PR TITLE
Adding a bitset implementation to manage usage of disk space

### DIFF
--- a/src/bitset.ml
+++ b/src/bitset.ml
@@ -1,0 +1,59 @@
+module Make (B : Context.A_DISK) = struct
+  module Sector = Sector.Make (B)
+  module Schema = Schema.Make (B)
+
+  type t = Sector.t
+
+  open Lwt_result.Syntax
+
+  let get t i =
+    let pos = i / 8 in
+    let* value = Sector.get_uint8 t pos in
+    let offset = i mod 8 in
+    let flag = value land (1 lsl offset) in
+    Lwt_result.return (flag = 0)
+
+  let free t i =
+    let pos = i / 8 in
+    if true then Format.printf "Sector %d being freed@." i ;
+    let* value = Sector.get_uint8 t pos in
+    let offset = i mod 8 in
+    let flag = value land (1 lsl offset) in
+    (* Format.printf "Value %d Flag %d@." value flag; *)
+    assert (flag > 0) ;
+    let update = value lxor (1 lsl offset) in
+    if pos = 0 then Format.printf "Value %d; Update %d; Flag %d@." value update flag ;
+    Sector.set_uint8 t pos update
+
+  let use t i =
+    let pos = i / 8 in
+    if true then Format.printf "Sector %d being used@." i ;
+    let* value = Sector.get_uint8 t pos in
+    let offset = i mod 8 in
+    let flag = value land (1 lsl offset) in
+    assert (flag = 0) ;
+    let update = value lor (1 lsl offset) in
+    if pos = 0 then Format.printf "Value %d; Update %d; Flag %d@." value update flag ;
+    (* Format.printf "Value %d Flag %d Offset %d Update %d@." value flag offset update; *)
+    Sector.set_uint8 t pos update
+
+  let create () =
+    Format.printf "create ;) @." ;
+    let* t = Sector.create () in
+    let sz = B.page_size in
+    let rec init = function
+      | i when i >= sz -> Lwt_result.return ()
+      | i ->
+        let* () = Sector.set_uint8 t i 0 in
+        init (i + 1)
+    in
+    let rec init_reserved = function
+      | i when i < 0 -> Lwt_result.return ()
+      | i ->
+        let* () = use t i in
+        init_reserved (i - 1)
+    in
+    let* () = init 0 in
+    let+ () = init_reserved 12 in
+    t
+end

--- a/src/bitset.ml
+++ b/src/bitset.ml
@@ -15,30 +15,23 @@ module Make (B : Context.A_DISK) = struct
 
   let free t i =
     let pos = i / 8 in
-    if true then Format.printf "Sector %d being freed@." i ;
     let* value = Sector.get_uint8 t pos in
     let offset = i mod 8 in
     let flag = value land (1 lsl offset) in
-    (* Format.printf "Value %d Flag %d@." value flag; *)
     assert (flag > 0) ;
     let update = value lxor (1 lsl offset) in
-    if pos = 0 then Format.printf "Value %d; Update %d; Flag %d@." value update flag ;
     Sector.set_uint8 t pos update
 
   let use t i =
     let pos = i / 8 in
-    if true then Format.printf "Sector %d being used@." i ;
     let* value = Sector.get_uint8 t pos in
     let offset = i mod 8 in
     let flag = value land (1 lsl offset) in
     assert (flag = 0) ;
     let update = value lor (1 lsl offset) in
-    if pos = 0 then Format.printf "Value %d; Update %d; Flag %d@." value update flag ;
-    (* Format.printf "Value %d Flag %d Offset %d Update %d@." value flag offset update; *)
     Sector.set_uint8 t pos update
 
   let create () =
-    Format.printf "create ;) @." ;
     let* t = Sector.create () in
     let sz = B.page_size in
     let rec init = function

--- a/src/bitset.ml
+++ b/src/bitset.ml
@@ -93,7 +93,9 @@ module Make (B : Context.A_DISK) = struct
 
   let rec create_parent size length =
     let* t = Sector.create () in
-    let rec loop = function
+    let rec loop pos =
+      Format.printf "Looping over position %d@." pos; 
+      match pos with 
       | pos when pos < 0 -> Lwt_result.return ()
       | pos when pos >= length - 1 ->
         let* parent = create_parent pos length in
@@ -111,7 +113,9 @@ module Make (B : Context.A_DISK) = struct
   let create () =
     let nb_sectors = Int64.to_int B.nb_sectors in
     let page_size = B.page_size in
+    Format.printf "size: %d, number: %d@." page_size nb_sectors;
     let* root = create_parent nb_sectors page_size in
+    Format.printf "Root done@.";
     let rec init_res = function
       | num when num < 0 -> Lwt_result.return ()
       | num ->
@@ -119,5 +123,6 @@ module Make (B : Context.A_DISK) = struct
         init_res (num - 1)
     in
     let+ () = init_res 12 in
+    Format.printf "Create done@.";
     root
 end

--- a/src/fs.ml
+++ b/src/fs.ml
@@ -85,7 +85,7 @@ module Make_disk (Clock : Mirage_clock.PCLOCK) (B : Context.A_DISK) :
       else Files.reachable_size t.files
     in
     let+ queue =
-      let* _, root_queue, _ = Root.get_free_queue t.root in
+      let* _, root_queue, _,  _ = Root.get_free_queue t.root in
       if Sector.is_null_ptr root_queue
       then Lwt_result.return 0
       else Queue.reachable_size t.free_queue

--- a/src/queue.ml
+++ b/src/queue.ml
@@ -129,7 +129,7 @@ module Make (B : Context.A_DISK) = struct
   let rec push_discarded ~quantity t bitset =
     let rec free = function
       | a :: b ->
-        let* () = Bitset.free bitset (Int64.to_int (B.Id.to_int64 a)) in
+        let* () = Bitset.free_range bitset a in
         free b
       | [] -> Lwt_result.return ()
     in
@@ -238,7 +238,7 @@ module Make (B : Context.A_DISK) = struct
   let push_back { free_start; free_queue; bitset; free_sectors } lst =
     let rec free = function
       | a :: b ->
-        let* () = Bitset.free bitset (Int64.to_int (B.Id.to_int64 a)) in
+        let* () = Bitset.free_range bitset a in
         free b
       | [] -> Lwt_result.return ()
     in
@@ -285,7 +285,7 @@ module Make (B : Context.A_DISK) = struct
     let* q, lst = pop_front t quantity in
     let rec use = function
       | a :: b ->
-        let* () = Bitset.use q.bitset (Int64.to_int (B.Id.to_int64 a)) in
+        let* () = Bitset.use_range q.bitset a in
         use b
       | [] -> Lwt_result.return ()
     in

--- a/src/queue.ml
+++ b/src/queue.ml
@@ -300,6 +300,7 @@ module Make (B : Context.A_DISK) = struct
   let finalize { free_start = f; free_queue = q; bitset; free_sectors } ids =
     let* tsqueue, rest = Sector.finalize q ids in
     let+ tsbitset, rest = Sector.finalize bitset rest in
+    (* List.iter (fun (id, _) -> Format.printf "Bitset at %d@." (Int64.to_int @@ B.Id.to_int64 id)) tsbitset; *)
     assert (rest = []) ;
     { free_start = f; free_queue = q; bitset; free_sectors }, tsqueue @ tsbitset
 

--- a/src/queue.mli
+++ b/src/queue.mli
@@ -4,12 +4,13 @@ module Make (B : Context.A_DISK) : sig
   type q =
     { free_start : Sector.id
     ; free_queue : Sector.t
+    ; bitset : Sector.t
     ; free_sectors : Int64.t
     }
 
   type 'a r := ('a, B.error) Lwt_result.t
 
-  val load : Sector.id * Sector.ptr * Int64.t -> q r
+  val load : Sector.id * Sector.ptr * Sector.ptr * Int64.t -> q r
   val verify_checksum : q -> unit r
   val push_back : q -> Sector.id list -> q r
   val push_discarded : q -> q r

--- a/src/schema.ml
+++ b/src/schema.ml
@@ -100,4 +100,5 @@ module Make (B : Context.A_DISK) = struct
   type ptr = (Sector.ptr, Sector.ptr) bifield
 
   let ptr : ptr t = make Sector.ptr_size Sector.get_child_ptr Sector.set_child_ptr
+  type uint8 = char field
 end


### PR DESCRIPTION
We use a bitset to manage the free space within the disk. The bitset uses 1 bit per sector to represent a sector is free or being used. Currently, the bitset manipulates only a single bit at a time but eventually it is expected to handle contiguous bits at a time. The bitset should work for up till `O(nb of bits in a sector ^ 2)` number of sectors but is still under testing.  