### PR TITLE
notafs-cli: add undocumented opam dependencies

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -32,6 +32,8 @@
   (synopsis "Notafs command-line tool")
   (depends
     (notafs :=version)
+    mirage-block-unix
+    mirage-clock-unix
     cmdliner
     fmt))
 

--- a/notafs-cli.opam
+++ b/notafs-cli.opam
@@ -10,6 +10,8 @@ bug-reports: "https://github.com/tarides/notafs/issues"
 depends: [
   "dune" {>= "3.1"}
   "notafs" {=version}
+  "mirage-block-unix"
+  "mirage-clock-unix"
   "cmdliner"
   "fmt"
   "odoc" {with-doc}


### PR DESCRIPTION
Hey there, thank you for the great work!

Here's a small patch for the CLI's opam file, which doesn't document its dependencies on `mirage-block/clock-unix`.