### PR TITLE
kv: rework example to expose pure KV

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,8 @@ As a work-in-progress demo, `notafs` includes a partial implementation of the [`
 To run the unikernel demos, you'll need to pin the `notafs` library, copy the `unikernel-kv` folder out of the project (to avoid recursive issues with `opam-monorepo`), compile it for your prefered Mirage target and create a disk to use:
 
 ```shell
-# Pin the library
-$ cd notafs
-notafs/ $ opam pin add notafs . --with-version=dev
-
 # Copy the mirage-kv demo to another folder
+$ cd notafs
 notafs/ $ cp -r unikernel-kv ../unikernel-kv
 notafs/ $ cd ../unikernel-kv
 

--- a/unikernel-kv/config.ml
+++ b/unikernel-kv/config.ml
@@ -1,5 +1,72 @@
 open Mirage
 
-let main = main "Unikernel.Main" (block @-> job) ~packages:[ package "notafs" ]
-let img = if_impl Key.is_solo5 (block_of_file "storage") (block_of_file "/tmp/storage")
-let () = register "block_test" [ main $ img ]
+(* This needs to be included until support for notafs is merged
+   in the upstream mirage tool. *)
+open (
+  struct
+    type checksum = CHECKSUM
+
+    let checksum_t = Type.v CHECKSUM
+
+    let notafs_kv_rw_conf ~format =
+      (* TODO remove pin when notafs is published on opam *)
+      let packages =
+        [ package ~pin:"git+https://github.com/tarides/notafs.git" "notafs" ]
+      in
+      let connect _ modname = function
+        | [ _pclock_v; _checksum; block_v ] ->
+            let connect_c = Fmt.str "%s.connect %s" modname block_v in
+            let format_c = Fmt.str "%s.format %s" modname block_v in
+            let connect_format_c =
+              match format with
+              | `Never -> connect_c
+              | `Always -> format_c
+              | `If_not ->
+                  Fmt.str
+                    {ml|%s >>= function
+                        | Error `Disk_not_formatted -> %s
+                        | x -> Lwt.return x|ml}
+                    connect_c format_c
+            in
+            code ~pos:__POS__
+              {ml|(%s)
+                >|= Result.map_error (Fmt.str "notafs_kv_rw: %%a" %s.pp_error)
+                >|= Result.fold ~ok:Fun.id ~error:failwith|ml}
+              connect_format_c modname
+        | _ -> connect_err "notafs_kv_rw" 3
+      in
+      impl ~packages ~connect "Notafs.KV"
+        (pclock @-> checksum_t @-> block @-> kv_rw)
+
+    let notafs_kv_rw ?(pclock = default_posix_clock) ?(checksum = `Adler32)
+        ?(format = `If_not) block =
+      let checksum_modname =
+        match checksum with
+        | `Adler32 -> "Notafs.Adler32"
+        | `No_checksum -> "Notafs.No_checksum"
+      in
+      let checksum = impl checksum_modname checksum_t in
+      notafs_kv_rw_conf ~format $ pclock $ checksum $ block
+  end :
+    sig
+      val notafs_kv_rw :
+        ?pclock:pclock impl ->
+        ?checksum:[ `Adler32 | `No_checksum ] ->
+        ?format:[ `Always | `Never | `If_not ] ->
+        block impl ->
+        kv_rw impl
+      (** [notafs_kv_rw ~checksum ~format block] exposes a KV_RW interface from
+          a notafs block, with the given checksum mechanism. The underlying
+          block is expected to be a well-formed notafs volume if
+          [format = `Never], is always formatted (and cleared) to be one if
+          [format = `Always], or only as needed (the first time it's opened) if
+          [format = `If_not] (the default). *)
+    end)
+
+let main = main "Unikernel.Main" (kv_rw @-> job)
+
+let block =
+  if_impl Key.is_solo5 (block_of_file "storage") (block_of_file "/tmp/storage")
+
+let kv = notafs_kv_rw block
+let () = register "block_test" [ main $ kv ]


### PR DESCRIPTION
Hi!

This PR does two things:

- pin `notafs` directly from the unikernel's `config.ml` so it doesn't need to be pinned manually (so that step is removed from the README)
- introduce a `notafs_kv_rw` function in `config.ml` that takes a block implementation (and a few other parameters, see the doc) and returns a `kv_rw` implementation, so that `notafs-kv` can be a real drop-in replacement for unikernels that already expect a `KV` (say, from a tar file)

A few thoughts:
- here, all that code is introduced in the example `config.ml`, but of course the goal would be to merge this code upstream in `mirage`. This can be a first draft towards that goal
- I change the example, but we could very well duplicate it (since this doesn't prevent people to directly use `Block` and the library, as done initialy) if you prefer
- we could have a `notafs_kv_ro` as well if needed
- currently `notafs_kv_rw` takes a `format` parameter to determine if the block should be formatted always, never or the first time. This could very well be a proper configure-time or run-time parameter as well
- the logic for connection could be slightly easier if `Notafs.KV` took the checksum implementation as its first argument instead of its second (we wouldn't need to define a type for checksums)